### PR TITLE
beautifying s3- declare of -a and -A types

### DIFF
--- a/s3
+++ b/s3
@@ -37,17 +37,17 @@ mkdir -p "$tcdir/native/bin" 2>/dev/null;
 [ -L "$workdir/profiles" ] || ln -sf "$profdir" "$workdir/profiles" 2>/dev/null;
 
 #set arrays
-array_names=( SHORT_PROTOCOLS SHORT_READERS SHORT_CARD_READERS AVAI_TCLIST MISS_TCLIST SHORT_ADDONS DISABLED_MODULES SHORT_MODULENAMES ALL_MODULES_LONG INTERNAL_MODULES ENABLED_MODULES INST_TCLIST SSH_CONF_CONTENT USE_vars USE_vars_disable s3cfg_vars )
+array_names_a=( SHORT_PROTOCOLS SHORT_READERS SHORT_CARD_READERS AVAI_TCLIST MISS_TCLIST SHORT_ADDONS DISABLED_MODULES SHORT_MODULENAMES ALL_MODULES_LONG  ENABLED_MODULES INST_TCLIST SSH_CONF_CONTENT )
+array_names_A=( INTERNAL_MODULES USE_vars USE_vars_disable s3cfg_vars )
 
-for a_n in "${array_names[@]}"; do
+for a_n in "${array_names_a[@]}"; do
     unset $a_n;
-    if [ "$a_n" == "INTERNAL_MODULES" ] || [ "$a_n" == "USE_vars" ] ||
-       [ "$a_n" == "USE_vars_disable" ] || [ "$a_n" == "s3cfg_vars" ];
-    then
-        declare -A $a_n;
-    else
-        declare -a $a_n;
-    fi;
+    declare -a $a_n;
+done
+
+for a_n in "${array_names_A[@]}"; do
+    unset $a_n;
+    declare -A $a_n;
 done
 
 USE_vars[USE_TARGZ]=;


### PR DESCRIPTION
it is easier to have only one place for the names of variables for declare -a and declare -A types in the source