### PR TITLE
Extend _sys_check to use it from plugins

### DIFF
--- a/support/functions/_sys_check
+++ b/support/functions/_sys_check
@@ -130,9 +130,9 @@ then
 	done
 fi
 
-binvars=( dialog grep gawk wget tar bzip2 svn xz upx patch gcc make scp sshpass openssl dos2unix );
-headervars=( crypto.h libusb.h pcsclite.h pthread.h )
-libvars=( libccidtwin.so )
+[ -z ${3+x} ] && binvars=( dialog grep gawk wget tar bzip2 svn xz upx patch gcc make scp sshpass openssl dos2unix ) || binvars=( $(echo "$3" | tr ' ' '\n') )
+[ -z ${4+x} ] && headervars=( crypto.h libusb.h pcsclite.h pthread.h ) || headervars=( $(echo "$4" | tr ' ' '\n') )
+[ -z ${5+x} ] && libvars=( libccidtwin.so ) || libvars=( $(echo "$5" | tr ' ' '\n') )
 sanity=1
 
 if ! prerequisites silent || [ "$now" == "now" ]


### PR DESCRIPTION
add usage of 3 optional parameter to set binvars, headervars and libvars
now its possible to reuse this function from plugins to check and install packages