### PR TITLE
s3.TUP new command to change config file (v0.12.0)

### DIFF
--- a/support/functions/_plugin_update_toolchain
+++ b/support/functions/_plugin_update_toolchain
@@ -3,7 +3,7 @@
 #simplebuild_plugin tcupdate
 
 tcupdate(){
-	pversion="0.11.5";
+	pversion="0.12.0";
 	pname="s3.TUP";
 	pdesc="Plugin $pname v$pversion";
 	configname="$configdir/plugin_update_toolchain.config";
@@ -17,6 +17,7 @@ tcupdate(){
 	[ -z "$4" ] && FLAG="0" || FLAG="$4"; #1 - tcupdate call from s3 main menu, 2 - tcupdate call from s3 toolchain menu;
 	tc="$CMDTC";
 	
+	#check/install prerequisites
 	clear && _check_pkg;
 
 	#backup config
@@ -45,11 +46,27 @@ tcupdate(){
 		_paktc_timer 5;
 	fi;
 	
+	#change config value's
+	if [ "$CMDTC" == "-cfg" ] || [ "$CMDTC" == "--config" ];then
+		_change_config "$OPTION1" "$OPTION2";
+		CMDTC="" && OPTION1="$2" &&	OPTION2="$3";
+	fi;
+	
 	#load config	
 	source "$configname";
 	
 	#check config
 	_check_config;
+	
+	#ct-ng must not be run as root unless you forcing it by config
+	if [ ! _check_root ] || [ "$CTNG_BUILD_AS_ROOT" == "1" ];then
+		CTNG_START_BUILD=1;
+	else
+		CTNG_START_BUILD=0;
+		sp=$(printf '%*s' 9);
+		CTNG_ROOT_BUILD_ERROR="\nERROR -> The execution of crosstool-NG was aborted because it must not run as root!\n\n""$sp""If you are aware of the danger of running crosstool-NG as root and you\n""$sp""know what you are doing, you can force it with the following command:\n\n";
+		CTNG_ROOT_BUILD_CMD="$sp""./s3 tcupdate --config \"CTNG_BUILD_AS_ROOT\" \"1\"\n";
+	fi;
 	
 	if [ "$CMDTC" == "-c" ] || [ "$CMDTC" == "--create" ];then	#start toolchain builder menu
 		_create_tc "$OPTION1" "" "$FLAG";
@@ -71,7 +88,7 @@ tcupdate(){
 		else
 			_nl && exit;
 		fi;
-	elif [ "$CMDTC" == "-ctng" ];then #croostool-NG menu
+	elif [ "$CMDTC" == "-ctng" ] || [ "$CMDTC" == "--crosstool-ng" ];then #croostool-NG menu
 		_ctng_menu "$OPTION1";
 		bye;
 	elif [ -z "$CMDTC" ];then
@@ -248,9 +265,6 @@ tcupdate(){
 _create_tc(){
 	_sz;					# Prepare DIALOG settings
 
-	#ct-ng must not be run as root unless you forcing it by config
-	! _check_root && START_BUILD=1 || [ "$CTNG_BUILD_AS_ROOT" == "1" ] && START_BUILD=1 || START_BUILD=0;
-	
 	local menu_close;
 	while [ ! $menu_close ]
 	do
@@ -296,7 +310,7 @@ _create_tc(){
 				if [ ! -f "$ctsrcdir/ct-ng" ]; then
 					echo -e "$r_l""\nCHECK -> crosstool-NG is not setup correctly. Try to fix it automatically...\n""$re_";
 					_paktc_timer 5;
-					_ctng_setup "$START_BUILD";
+					_ctng_setup "$CTNG_START_BUILD";
 				fi;
 				
 				#Build cross toolchains
@@ -329,7 +343,7 @@ _create_tc(){
 						echo -e "cd \"$ctsrcdir\";\n$(_replace_tokens "$bcl")\n$sp""$re_" | tee -a "$logfile";
 						sleep 2;
 
-						if [ $START_BUILD -eq 1 ]; then
+						if [ $CTNG_START_BUILD -eq 1 ]; then
 							cd "$ctsrcdir";
 							#print out crosstool-NG version
 							echo -e "$g_l\n$(./ct-ng | grep 'crosstool-NG version' &2>/dev/null | tail -1)\n""$re_" | tee -a "$logfile";
@@ -363,7 +377,7 @@ _create_tc(){
 								_paktc_timer 10;
 							fi;
 						else
-							echo -e "$r_l""\nERROR -> The execution of crosstool-NG was aborted\n         because it must not run as root!\n""$re_" | tee -a "$logfile";
+							echo -e "$r_l""$CTNG_ROOT_BUILD_ERROR""$y_l""$CTNG_ROOT_BUILD_CMD""$re_" | tee -a "$logfile";
 							_paktc_timer 10;
 						fi;
 					else
@@ -372,7 +386,7 @@ _create_tc(){
 					fi;
 				done;;
 			1) #Setup - Setup crosstool-NG
-				_ctng_setup "$START_BUILD";
+				_ctng_setup "$CTNG_START_BUILD";
 				_paktc_timer 10;;
 			2) #Edit
 				tpl=$(echo "$opts" | awk '{printf $2}';);
@@ -473,7 +487,7 @@ _ctng_setup(){
 		done
 		( eval "${setuptasks[@]}" ) 2>&1;
 	else
-		echo -e "\nERROR -> The execution of crosstool-NG was aborted\n         because it must not run as root!\n";
+		echo -e "$CTNG_ROOT_BUILD_ERROR$CTNG_ROOT_BUILD_CMD"
 	fi;
 	) | tee "$logfile" | "$gui" "$st_" "$bt_" "$title_ - \Z0$pdesc\Zn" "--colors" "--title" " -[ Setup crosstool-NG ]- " "$pb_" "$_lines" "$_cols";
 };
@@ -644,19 +658,6 @@ _check_pkg(){
 		echo -e "$r_l""\nCHECK -> You need to manually install the following packages to use this plugin properly:\n"$y_l"$prefix apt install$packages\n""$re_" && _paktc_timer 10;
 	fi;
 };
-_check_config(){
-	nok=0;
-	[ -z ${CTNG_CONFIG_tasks+x} ] && nok=1;
-	[ -z ${CTNG_BUILD_AS_ROOT+x} ] && nok=1;
-	[ -z ${LIBS+x} ] && nok=1;
-	
-	if [ $nok -eq 1 ]; then 
-		clear;
-		echo -e "$r_l""\nCHECK -> Your config file seems to be outdated. Please restart s3 as follows to recreate an updated config file:\n"$y_l"./s3 tcupdate -r\n""$re_";
-		_paktc_timer 10;
-		return $nok;
-	fi;
-};	
 _check_github_api_limits(){
 	
 	limit=$(curl --silent "https://api.github.com/rate_limit" | jq -r '.resources.core.limit');
@@ -675,6 +676,40 @@ _check_github_api_limits(){
 	else
 		return 1;
 	fi;
+};
+_check_config(){
+	nok=0;
+	[ -z ${CTNG_CONFIG_tasks+x} ] && nok=1;
+	[ -z ${CTNG_BUILD_AS_ROOT+x} ] && nok=1;
+	[ -z ${LIBS+x} ] && nok=1;
+	
+	if [ $nok -eq 1 ]; then 
+		clear;
+		echo -e "$r_l""\nCHECK -> Your config file seems to be outdated. Please restart s3 as follows to recreate an updated config file:\n"$y_l"./s3 tcupdate -r\n""$re_";
+		_paktc_timer 10;
+		return $nok;
+	fi;
+};	
+_change_config(){
+	nok=1;
+	ts="$(date +%F) $(date +%T)";
+	[[ ! $2 =~ "(" ]] && [[ ! $string =~ ")" ]] && qte="\"" || qte=""; #no quotes if value contains parentheses
+	
+	if ! grep -Eq "^$1=.*" "$configname";then
+		echo -e "$r_l""\nCHECK -> Variable "$y_l"$1"$r_l" does not exist in the configuration file!\n""$re_";
+		_paktc_timer 10;
+	elif [ "${1:(-6)}" == "_tasks" ];then
+		echo -e "$r_l""\nCHECK -> Modifying "$y_l"tasks-variables"$r_l" not implemented yet!\n""$re_";
+		_paktc_timer 10;
+	else
+		sed -i "s#^$1=.*#$1=$qte$2$qte; \#changed on $ts via tcupdate commandline#g" "$configname";
+		result=$(grep -E "^$1=.*" "$configname" | awk '{printf $1}');
+		echo -e "$g_l""\nDONE -> Variable changed to: "$y_l"$result\n""$re_";
+		_paktc_timer 5;
+		nok=0;
+	fi;
+
+	return $nok;
 };
 _create_config(){
 	#check existing jq


### PR DESCRIPTION
new commandline option -cfg | --config to change configuration values via tcupdate (e.g. ./s3 tcupdate --config "CTNG_BUILD_AS_ROOT" "1" #enable build as root)
extend commandline option -ctng with the long version --crosstool-ng
rewwork on build as root error messages