### PR TITLE
Add patchelf functionality

### DIFF
--- a/support/functions/_cmd_build
+++ b/support/functions/_cmd_build
@@ -234,6 +234,13 @@ fi
 #show build time
 	printf "$g_n""\n TIME -------> $bt$re_\n\n"
 
+#patchelf
+	if [ -n "$_patchelf" ]
+	then
+		printf "$w_l"" ENABLE -----> PATCHELF:$y_l $_patchelf...\n"
+		eval "patchelf "$_patchelf" "$bdir/$oscam_name""
+	fi;
+
 #compress cam
 	if [ "${s3cfg_vars[COMPRESS]}" == "1" ]
 	then

--- a/support/functions/_gui_build
+++ b/support/functions/_gui_build
@@ -126,8 +126,16 @@ _gui_build(){
 	then
 		rm "$bdir/$oscam_name.debug"
 		printf "\n $txt_delete $oscam_name.debug\n"|tee -a "$ldir/$log_name"
-	fi;) | "$gui" "$st_" --colors --title " -[ Build ]- " "$pb_" "$_lines" "$_cols"
+	fi;
 	sleep 2
+
+#patchelf
+	if [ -n "$_patchelf" ]
+	then
+		printf "\n patchelf $_patchelf\n"|tee -a "$ldir/$log_name"
+		eval "patchelf "$_patchelf" "$bdir/$oscam_name""
+	fi;) | "$gui" "$st_" --colors --title " -[ Build ]- " "$pb_" "$_lines" "$_cols"
+	sleep 1
 
 #COMPRESS
 	if [ ! "$stapi_allowed" == "1" ]

--- a/support/functions/_sys_check
+++ b/support/functions/_sys_check
@@ -131,7 +131,7 @@ then
 fi
 
 unset binvars; unset headervars; unset libvars;
-[ -z ${3+x} ] && binvars=( dialog grep gawk wget tar bzip2 svn xz upx patch gcc make scp sshpass openssl dos2unix ) || binvars=( $(echo "$3" | tr ' ' '\n') )
+[ -z ${3+x} ] && binvars=( dialog grep gawk wget tar bzip2 svn xz upx patch gcc make scp sshpass openssl dos2unix patchelf) || binvars=( $(echo "$3" | tr ' ' '\n') )
 [ -z ${4+x} ] && headervars=( crypto.h libusb.h pcsclite.h pthread.h ) || headervars=( $(echo "$4" | tr ' ' '\n') )
 [ -z ${5+x} ] && libvars=( libccidtwin.so ) || libvars=( $(echo "$5" | tr ' ' '\n') )
 sanity=1


### PR DESCRIPTION
if exists `_patchelf`-variable in toolchain.cfg (e.g. `_patchelf="--set-interpreter '/usr/lib/freetz/ld-uClibc.so.1'";`) then patchelf ist executed before COMPRESS. Useful for fritzbox toolchains for FritzOS > 7.20.

This is one resolution for problem described in: https://board.streamboard.tv/forum/thread/37367-simplebuild-3-talk-in-en-de-firstpost-changelog/?postID=600978#post600978
