### PR TITLE
Add use of EXTRA_LDFLAGS functionality via toolchain.cfg

### DIFF
--- a/support/functions/_cmd_build
+++ b/support/functions/_cmd_build
@@ -191,6 +191,7 @@ fi
 	"OSCAM_BIN=$bdir/$oscam_name" \
 	"CC_OPTS=$co $cc_opts $extra_cc" \
 	"CC_WARN=$cc_warn" \
+	"EXTRA_LDFLAGS=$extra_ld" \
 	$EXTRA_USE \
 	"CROSS=$CROSS" $STAPI_LIB $USESTRING 2>&1 \
 	|tee -a "$ldir/$log_name" \

--- a/support/functions/_gui_build
+++ b/support/functions/_gui_build
@@ -89,7 +89,7 @@ _gui_build(){
 	(ologo; _nl
 	timer_start
 	make -j"$cpus" \
-		"CONF_DIR=$_oscamconfdir_default" "OSCAM_BIN=$bdir/$oscam_name" "CC_OPTS=$co $cc_opts $extra_cc" "CC_WARN=$cc_warn" $EXTRA_USE "CROSS=$CROSS" $stapivar $USESTRING_ 2>&1 \
+		"CONF_DIR=$_oscamconfdir_default" "OSCAM_BIN=$bdir/$oscam_name" "CC_OPTS=$co $cc_opts $extra_cc" "CC_WARN=$cc_warn" "EXTRA_LDFLAGS=$extra_ld" $EXTRA_USE "CROSS=$CROSS" $stapivar $USESTRING_ 2>&1 \
 		|tee "$ldir/$log_name" \
 		|grep --line-buffered -v 'BFD\|^/' \
 		|grep --line-buffered '^CC\|^GEN\|UseFlags\|  CONF_DIR =\|Binary\|LINK\|STRIP\|BUILD\|Addons\|Protocols\|Readers\|CardRdrs\|^/' \


### PR DESCRIPTION
This is the resolution for problem described in: https://board.streamboard.tv/forum/thread/37367-simplebuild-3-talk-in-en-de-firstpost-changelog/?postID=600978#post600978

e.g.
To change the linker during build process for the resulting oscam binary (FritzBox 7590 FOS 7.2x), set `extra_ld="-Wl,-dynamic-linker,/usr/lib/freetz/ld-uClibc.so.0";` in toolchain.cfg

@gorgone: Is well tested, and mergable